### PR TITLE
refactor: use standard platform macros

### DIFF
--- a/include/host/backends/vk/ffxm_vk.h
+++ b/include/host/backends/vk/ffxm_vk.h
@@ -27,12 +27,12 @@
 #pragma once
 
 #ifdef FFXM_VKLOADER_VOLK
-#if FFXM_FSR2_PLATFORM_LINUX
+#if defined(__linux__)
 #	define VK_USE_PLATFORM_XCB_KHR 1
 #	define VK_USE_PLATFORM_XLIB_KHR 1
-#elif FFXM_FSR2_PLATFORM_WINDOWS
+#elif defined(_WIN32)
 #	define VK_USE_PLATFORM_WIN32_KHR 1
-#elif FFXM_FSR2_PLATFORM_ANDROID
+#elif defined(__ANDROID__)
 #	define VK_USE_PLATFORM_ANDROID_KHR 1
 #else
 #	error Not implemented

--- a/src/backends/vk/CMakeLists.txt
+++ b/src/backends/vk/CMakeLists.txt
@@ -173,13 +173,6 @@ include_directories(${FFXM_VULKAN_PATH})
 
 # Add some defines
 target_compile_definitions(Arm_ASR_backend PUBLIC FFXM_VKLOADER_VOLK=1)
-if(WINDOWS)
-	target_compile_definitions(Arm_ASR_backend PUBLIC FFXM_FSR2_PLATFORM_WINDOWS=1)
-elseif(LINUX)
-	target_compile_definitions(Arm_ASR_backend PUBLIC FFXM_FSR2_PLATFORM_LINUX=1)
-elseif(ANDROID)
-	target_compile_definitions(Arm_ASR_backend PUBLIC FFXM_FSR2_PLATFORM_ANDROID=1)
-endif()
 
 get_filename_component(FFXM_PASS_SHADER_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/../shaders/vk ABSOLUTE)
 include_directories(${FFXM_PASS_SHADER_OUTPUT_PATH})

--- a/src/backends/vk/ffxm_vk.cpp
+++ b/src/backends/vk/ffxm_vk.cpp
@@ -381,7 +381,7 @@ FfxmUInt32 findMemoryTypeIndex(VkPhysicalDevice physicalDevice, VkMemoryRequirem
     for (FfxmUInt32 i = 0; i < memProperties.memoryTypeCount; i++) {
         if ((memRequirements.memoryTypeBits & (1 << i)) && (memProperties.memoryTypes[i].propertyFlags & requestedProperties)) {
 
-#ifndef FFXM_FSR2_PLATFORM_ANDROID
+#ifndef __ANDROID__
             // if just device-local memory is requested, make sure this is the invisible heap to prevent over-subscribing the local heap
             if (requestedProperties == VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT && (memProperties.memoryTypes[i].propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT))
                 continue;


### PR DESCRIPTION
Use standard platform macros (__linux__, _WIN32, __ANDROID__) instead of custom FFXM_FSR2_PLATFORM_* defines.

Resolves: MLXPK-1132


Change-Id: I11ed128a26708784ad1e5fba1c05080caa312ed1